### PR TITLE
do not ask asset pipeline for skipped resources

### DIFF
--- a/lib/percy/capybara/loaders/sprockets_loader.rb
+++ b/lib/percy/capybara/loaders/sprockets_loader.rb
@@ -30,6 +30,8 @@ module Percy
         def build_resources
           resources = []
           _asset_logical_paths.each do |logical_path|
+            next if SKIP_RESOURCE_EXTENSIONS.include?(File.extname(logical_path))
+            
             asset = sprockets_environment.find_asset(logical_path)
             content = asset.to_s
             sha = Digest::SHA256.hexdigest(content)


### PR DESCRIPTION
asset pipeline can raise `Sprockets::Helpers::RailsHelper::AssetPaths::AssetNotPrecompiledError`
or similar when the asset is not precompiled

but the real asset path is not really needed to skip files based on extension