### PR TITLE
Add support for .percy-capybara.yml config file

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,6 @@
+# This is the default configuration file.
+# A custom configuration file will completely override this one.
+
+sprockets_loader:
+  ignore_paths:
+    - '.*\.map\z'

--- a/lib/percy/capybara/client.rb
+++ b/lib/percy/capybara/client.rb
@@ -2,6 +2,7 @@ require 'percy/capybara/client/builds'
 require 'percy/capybara/client/snapshots'
 require 'percy/capybara/loaders/native_loader'
 require 'percy/capybara/loaders/sprockets_loader'
+require 'percy/capybara/config_loader'
 
 module Percy
   module Capybara
@@ -22,11 +23,15 @@ module Percy
       def initialize(options = {})
         @client = options[:client] || Percy.client
         @enabled = options[:enabled]
+        config_loader = Percy::Capybara::ConfigLoader
 
         if defined?(Rails)
           @sprockets_environment = options[:sprockets_environment] || Rails.application.assets
           @sprockets_options = options[:sprockets_options] || Rails.application.config.assets
+          @config = config_loader.load_rails_dotfile
         end
+
+        @config ||= config_loader.load_default
       end
 
       def enabled?
@@ -63,6 +68,8 @@ module Percy
       end
 
       def initialize_loader(options = {})
+        options[:config] ||= @config
+
         if custom_loader
           Percy.logger.debug { 'Using a custom loader to discover assets.' }
           custom_loader.new(options)

--- a/lib/percy/capybara/config_loader.rb
+++ b/lib/percy/capybara/config_loader.rb
@@ -1,0 +1,52 @@
+module Percy
+  module Capybara
+    class ConfigLoader
+      DOTFILE = '.percy-capybara.yml'.freeze
+      PERCY_CAPYBARA_HOME = File.realpath(File.join(File.dirname(__FILE__), '..', '..', '..'))
+      DEFAULT_FILE = File.join(PERCY_CAPYBARA_HOME, 'config', 'default.yml')
+
+      class << self
+        def load_default
+          load_yaml_configuration(DEFAULT_FILE)
+        end
+
+        def load_yaml_configuration(absolute_path)
+          yaml_code = IO.read(absolute_path, encoding: 'UTF-8')
+          # At one time, there was a problem with the psych YAML engine under
+          # Ruby 1.9.3. YAML.load_file would crash when reading empty .yml files
+          # or files that only contained comments and blank lines. This problem
+          # is not possible to reproduce now, but we want to avoid it in case
+          # it's still there. So we only load the YAML code if we find some real
+          # code in there.
+          hash = yaml_code =~ /^[A-Z]/i ? yaml_safe_load(yaml_code) : {}
+          
+          raise(TypeError, "Malformed configuration in #{absolute_path}") unless hash.is_a?(Hash)
+
+          hash
+        end
+
+        # Rails
+        def load_rails_dotfile
+          load_yaml_configuration(rails_dotfile) if rails_dotfile_exists?
+        end
+
+        def rails_dotfile
+          Rails.root.join(DOTFILE)
+        end
+
+        def rails_dotfile_exists?
+          File.exist?(rails_dotfile)
+        end
+
+        # @private
+        def yaml_safe_load(yaml_code)
+          if YAML.respond_to?(:safe_load) # Ruby 2.1+
+            YAML.safe_load(yaml_code)
+          else
+            YAML.load(yaml_code)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/percy/capybara/loaders/sprockets_loader_spec.rb
+++ b/spec/lib/percy/capybara/loaders/sprockets_loader_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Percy::Capybara::Loaders::SprocketsLoader do
       page: page,
       sprockets_environment: environment,
       sprockets_options: sprockets_options,
+      config: Percy::Capybara::ConfigLoader.load_default
     )
   end
   let(:environment) do
@@ -88,6 +89,32 @@ RSpec.describe Percy::Capybara::Loaders::SprocketsLoader do
             '/assets/css/digested-f3420c6aee71c137a3ca39727052811bae84b2f37d898f4db242e20656a1579e.css'
           digested_resources = resources.select { |r| r.resource_url == expected_digest_url }
           expect(digested_resources.length).to eq(1)
+        end
+      end
+      context 'with config set ignored paths' do
+        let(:loader) do
+          described_class.new(
+            page: page,
+            sprockets_environment: environment,
+            sprockets_options: sprockets_options,
+            config: config
+          )
+        end
+        let(:config) do
+          {
+            'sprockets_loader' => {
+              'ignore_paths' => [
+                '/images',
+                'test-.*\.html'
+              ]
+            }
+          }
+        end
+        it 'returns "build resources" from filtered sprockets paths' do
+          resources = loader.build_resources
+          resources_urls = resources.map(&:resource_url)
+          expect(resources_urls).not_to include('/images/percy.svg')
+          expect(resources_urls).not_to include('/test-images.html')
         end
       end
     end


### PR DESCRIPTION
**Why**
- Needed a configurable way to ignore files to be uploaded as build resources

**How**
- In rails apps, automatically loads `[RAILS]/.percy-capybara.yml`
- By default, loads `[GEM]/config/default.yml`

**Current configuration option currently supported**
- `ignore_paths` for `sprockets_loader` (regexes as strings)

