### PR TITLE
Make specs pass on forked repos

### DIFF
--- a/spec/lib/percy/capybara/client/builds_spec.rb
+++ b/spec/lib/percy/capybara/client/builds_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe Percy::Capybara::Client::Builds do
   let(:enabled) { true }
   let(:capybara_client) { Percy::Capybara::Client.new(enabled: enabled) }
+  let(:builds_api_url) { "https://percy.io/api/v1/repos/#{Percy::Client::Environment.repo}/builds/" }
 
   describe '#initialize_build', type: :feature, js: true do
     before(:each) { setup_sprockets(capybara_client) }
@@ -18,7 +19,7 @@ RSpec.describe Percy::Capybara::Client::Builds do
           'type' => 'builds',
         },
       }
-      stub_request(:post, 'https://percy.io/api/v1/repos/percy/percy-capybara/builds/')
+      stub_request(:post, builds_api_url)
         .to_return(status: 201, body: mock_response.to_json)
       expect(capybara_client.initialize_build).to eq(mock_response)
     end
@@ -43,7 +44,7 @@ RSpec.describe Percy::Capybara::Client::Builds do
         },
       }
       # Stub create build.
-      build_stub = stub_request(:post, 'https://percy.io/api/v1/repos/percy/percy-capybara/builds/')
+      build_stub = stub_request(:post, builds_api_url)
         .to_return(status: 201, body: mock_response.to_json)
 
       # Stub resource upload.
@@ -81,7 +82,7 @@ RSpec.describe Percy::Capybara::Client::Builds do
         },
       }
       # Stub create build.
-      build_stub = stub_request(:post, 'https://percy.io/api/v1/repos/percy/percy-capybara/builds/')
+      build_stub = stub_request(:post, builds_api_url)
         .to_return(status: 201, body: mock_response.to_json)
 
       # Stub resource upload.
@@ -156,7 +157,7 @@ RSpec.describe Percy::Capybara::Client::Builds do
           'type' => 'builds',
         },
       }
-      stub_request(:post, 'https://percy.io/api/v1/repos/percy/percy-capybara/builds/')
+      stub_request(:post, builds_api_url)
         .to_return(status: 201, body: mock_response.to_json)
       capybara_client.initialize_build
 

--- a/spec/lib/percy/capybara/client/snapshots_spec.rb
+++ b/spec/lib/percy/capybara/client/snapshots_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe Percy::Capybara::Client::Snapshots, type: :feature do
       before :each do
         visit '/'
         loader  # Force evaluation now.
-        stub_request(:post, 'https://percy.io/api/v1/repos/percy/percy-capybara/builds/')
+        repo = Percy::Client::Environment.repo
+        stub_request(:post, "https://percy.io/api/v1/repos/#{repo}/builds/")
           .to_return(status: 201, body: mock_build_response.to_json)
         stub_request(:post, 'https://percy.io/api/v1/builds/123/snapshots/')
           .to_return(status: 201, body: mock_snapshot_response.to_json)


### PR DESCRIPTION
When running specs from my forked repo (mfazekas/percy-capybara) i get error like this:

```ruby
  7) Percy::Capybara::Client::Builds#initialize_build initializes and returns a build
     Failure/Error: @current_build = client.create_build(client.config.repo, options)
     
     WebMock::NetConnectNotAllowedError:
       Real HTTP connections are disabled. Unregistered request: POST https://percy.io/api/v1/repos/mfazekas/percy-capybara/builds/ with body '{"data":{"type":"builds","attributes":{"branch":"master","target-branch":null,"commit-sha":"06f42b96337e8f9d9b97427a919969a835e4e750","commit-committed-at":"2016-10-12 11:12:58 -0700","commit-author-
```

The patch replaces ```https://percy.io/api/v1/repos/percy/percy-capybara/builds/``` with ```https://percy.io/api/v1/repos/#{Percy::Client::Environment.repo}/builds/```