### PR TITLE
Support for nonlocal hosts.

### DIFF
--- a/spec/lib/percy/capybara/client/testdata/test-localtest-me-images.html
+++ b/spec/lib/percy/capybara/client/testdata/test-localtest-me-images.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <title>Test Percy::Capybara</title>
+  <h1>Test images</h1>
+
+  <h2>img local PNG (relative)</h2>
+  <img src="/images/img-relative.png"></img>
+</html>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'percy/capybara'
 
 Capybara::Webkit.configure do |config|
   # config.allow_url("*")
+  config.allow_url('localtest.me')
   config.block_unknown_urls
 end
 


### PR DESCRIPTION
Fixes: #8 

When running percy against non localhost/127.0.0.1/0.0.0.0 url, percy.io was missing css, and img resources. (We want to use percy to check staging, so test non local service, but some might be just using other alias to localhost like localtest.me)

It works by using capybara's current_url, and is a resource is coming from same scheme/host/port then we're just using the path for uploading (bug for downloading we're still using the full url). So before a resource was referred as ```http://localhost/css/imports.css``` now it's just ```/css/imports.css```