### PR TITLE
Prevent several warnings

### DIFF
--- a/lib/percy/capybara/client.rb
+++ b/lib/percy/capybara/client.rb
@@ -20,6 +20,8 @@ module Percy
       attr_accessor :custom_loader
 
       def initialize(options = {})
+        @failed = false
+
         @client = options[:client] || Percy.client
         @enabled = options[:enabled]
 

--- a/lib/percy/capybara/client/builds.rb
+++ b/lib/percy/capybara/client/builds.rb
@@ -32,6 +32,7 @@ module Percy
         end
 
         def build_initialized?
+          return false unless defined? @current_build
           !!@current_build
         end
 

--- a/lib/percy/capybara/loaders/native_loader.rb
+++ b/lib/percy/capybara/loaders/native_loader.rb
@@ -77,7 +77,6 @@ module Percy
             response = _fetch_resource_url(url)
             _absolute_url_to_relative!(url, _current_host_port)
             next if !response
-            sha = Digest::SHA256.hexdigest(response.body)
             resources << Percy::Client::Resource.new(
               url, mimetype: 'text/css', content: response.body)
           end
@@ -164,7 +163,6 @@ module Percy
             _absolute_url_to_relative!(resource_url, _current_host_port)
             next if !response
 
-            sha = Digest::SHA256.hexdigest(response.body)
             resources << Percy::Client::Resource.new(
               resource_url, mimetype: response.content_type, content: response.body)
           end
@@ -210,10 +208,10 @@ module Percy
           !!result
         end
 
-        # @priivate
+        # @private
         def _current_host_port
           url_match = URL_REGEX.match(page.current_url)
-          host_port = url_match[1] + url_match[2] + (url_match[3] || '')
+          url_match[1] + url_match[2] + (url_match[3] || '')
         end
 
         # @private

--- a/spec/lib/percy/capybara/client/builds_spec.rb
+++ b/spec/lib/percy/capybara/client/builds_spec.rb
@@ -89,7 +89,6 @@ RSpec.describe Percy::Capybara::Client::Builds do
       expect(capybara_client.client).to receive(:upload_resource)
         .and_raise(Percy::Client::ConnectionFailed)
 
-      result = capybara_client.initialize_build
       expect(capybara_client.initialize_build).to eq(nil)
       expect(capybara_client.failed?).to eq(true)
       expect(build_stub).to have_been_requested

--- a/spec/lib/percy/capybara_spec.rb
+++ b/spec/lib/percy/capybara_spec.rb
@@ -70,7 +70,6 @@ RSpec.describe Percy::Capybara do
   end
   describe '#disable!' do
     it 'sets the current capybara_client to disabled' do
-      capybara_client = Percy::Capybara.capybara_client
       expect(Percy::Capybara.capybara_client.enabled?).to eq(true)
       Percy::Capybara.disable!
       expect(Percy::Capybara.capybara_client.enabled?).to eq(false)
@@ -80,7 +79,6 @@ RSpec.describe Percy::Capybara do
     class DummyLoader < Percy::Capybara::Loaders::NativeLoader; end
 
     it 'sets the current capybara clients custom loader' do
-      capybara_client = Percy::Capybara::Client
       expect(Percy::Capybara.capybara_client.custom_loader).to_not be
       Percy::Capybara.use_loader(DummyLoader)
       expect(Percy::Capybara.capybara_client.custom_loader).to be


### PR DESCRIPTION
Prevent several warnings:

* Initialize @failed variable before it's used
* build_initialized? now returns false if @current_build isn't defined 
* Remove calculation of sha in 2 places it's not used
* Remove setting of host_port where the variable isn't used
* Remove setting of capybara_client in specs where it's not used.