### PR TITLE
Enable by default, disable if PERCY_ENABLE=0

### DIFF
--- a/lib/percy/capybara/client.rb
+++ b/lib/percy/capybara/client.rb
@@ -34,11 +34,11 @@ module Percy
       def enabled?
         return @enabled if !@enabled.nil?
 
-        # Enable if PERCY_ENABLE=1 in local dev (allow disabling if 0).
-        return @enabled ||= ENV['PERCY_ENABLE'] == '1' if ENV['PERCY_ENABLE']
+        # Disable if PERCY_ENABLE is set to 0
+        return @enabled = false if ENV['PERCY_ENABLE'] == '0'
 
-        # If in supported CI environment.
-        @enabled ||= !Percy::Client::Environment.current_ci.nil?
+        # Enable otherwise
+        return @enabled = true
       end
 
       def disable!

--- a/spec/lib/percy/capybara/client_spec.rb
+++ b/spec/lib/percy/capybara/client_spec.rb
@@ -20,12 +20,20 @@ RSpec.describe Percy::Capybara::Client do
         expect(Percy::Capybara::Client.new.enabled?).to eq(true)
       end
     end
-    it 'is false by default for local dev environments or unknown CI environments' do
-      expect(Percy::Capybara::Client.new.enabled?).to eq(false)
+    it 'is true by default for local dev environments and unknown CI environments' do
+      expect(Percy::Capybara::Client.new.enabled?).to eq(true)
     end
     it 'is true if PERCY_ENABLE=1 is set' do
       ENV['PERCY_ENABLE'] = '1'
       expect(Percy::Capybara::Client.new.enabled?).to eq(true)
+    end
+    it 'is true if PERCY_ENABLE isn\'t set' do
+      ENV.delete('PERCY_ENABLE')
+      expect(Percy::Capybara::Client.new.enabled?).to eq(true)
+    end
+    it 'is false if PERCY_ENABLE=0 is set' do
+      ENV['PERCY_ENABLE'] = '0'
+      expect(Percy::Capybara::Client.new.enabled?).to eq(false)
     end
   end
   describe '#failed?' do
@@ -107,4 +115,3 @@ RSpec.describe Percy::Capybara::Client do
     end
   end
 end
-

--- a/spec/lib/percy/capybara_spec.rb
+++ b/spec/lib/percy/capybara_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Percy::Capybara do
   end
   after(:each) do
     ENV['TRAVIS_BUILD_ID'] = @original_env
-    ENV['PERCY_ENABLE'] = nil
+    ENV.delete('PERCY_ENABLE')
   end
 
   describe '#capybara_client' do
@@ -27,8 +27,8 @@ RSpec.describe Percy::Capybara do
       expect(capybara_client).to receive(:snapshot).with(mock_page, name: '/foo.html (modal)').once
       Percy::Capybara.snapshot(mock_page, name: '/foo.html (modal)')
     end
-    it 'silently skips if not enabled' do
-      ENV['PERCY_ENABLE'] = nil
+    it 'silently skips if disabled' do
+      ENV['PERCY_ENABLE'] = '0'
       mock_page = double('page')
       Percy::Capybara.snapshot(mock_page)
     end
@@ -52,8 +52,8 @@ RSpec.describe Percy::Capybara do
       expect(capybara_client).to receive(:finalize_current_build).once
       Percy::Capybara.finalize_build
     end
-    it 'silently skips if not enabled' do
-      ENV['PERCY_ENABLE'] = nil
+    it 'silently skips if disabled' do
+      ENV['PERCY_ENABLE'] = '0'
       capybara_client = Percy::Capybara.capybara_client
       expect(capybara_client.client).to_not receive(:create_build)
       Percy::Capybara.initialize_build


### PR DESCRIPTION
@fotinakis Change made, and specs updated.

I guess this also enables it in unknown CI providers.  I suspect this is okay as it'll still require the customer to specify the key and project in the environment, and they will have seen that their provider isn't in the list of supported ones.  I'd like your sanity check on this though.  :)