### PR TITLE
Fix module path import loading issues.

### DIFF
--- a/lib/percy/capybara/loaders/base_loader.rb
+++ b/lib/percy/capybara/loaders/base_loader.rb
@@ -1,3 +1,5 @@
+require 'percy/capybara'
+
 module Percy
   module Capybara
     module Loaders


### PR DESCRIPTION
For one user, sometimes this happens:

```
undefined method `client' for Percy:Module (NoMethodError)
```

When they use a custom loader like:

```ruby
require 'percy/capybara/loaders/sprockets_loader'

class CustomLoader < Percy::Capybara::Loaders::SprocketsLoader
...
end

Percy::Capybara.use_loader(CustomLoader)
Percy::Capybara.initialize_build
at_exit  { Percy::Capybara.finalize_build }
```