### PR TITLE
Fix double-slash bug when baseurl is set to /.

### DIFF
--- a/lib/percy/capybara/loaders/filesystem_loader.rb
+++ b/lib/percy/capybara/loaders/filesystem_loader.rb
@@ -17,7 +17,7 @@ module Percy
         def initialize(options = {})
           # @assets_dir should point to a _compiled_ static assets directory, not source assets.
           @assets_dir = options[:assets_dir]
-          @base_url = options[:base_url] || ''
+          @base_url = options[:base_url] || '/'
 
           raise ArgumentError, 'assets_dir is required' if @assets_dir.nil? || @assets_dir == ''
           unless Pathname.new(@assets_dir).absolute?
@@ -45,7 +45,7 @@ module Percy
             next if File.size(path) > MAX_FILESIZE_BYTES
 
             # Replace the assets_dir with the base_url to generate the resource_url
-            resource_url = path.sub(@assets_dir, @base_url)
+            resource_url = @base_url.chomp('/') + path.sub(@assets_dir, '')
 
             sha = Digest::SHA256.hexdigest(File.read(path))
             resources << Percy::Client::Resource.new(resource_url, sha: sha, path: path)

--- a/spec/lib/percy/capybara/client/builds_spec.rb
+++ b/spec/lib/percy/capybara/client/builds_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Percy::Capybara::Client::Builds do
 
     context 'percy is not enabled' do
       let(:enabled) { false }
+
       it 'returns nil if not enabled' do
         expect(capybara_client.initialize_build).to be_nil
       end

--- a/spec/lib/percy/capybara/client/snapshots_spec.rb
+++ b/spec/lib/percy/capybara/client/snapshots_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Percy::Capybara::Client::Snapshots, type: :feature do
           },
         }
       end
+
       before do
         setup_sprockets(capybara_client)
 

--- a/spec/lib/percy/capybara/client_spec.rb
+++ b/spec/lib/percy/capybara/client_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Percy::Capybara::Client do
   end
   describe '#rescue_connection_failures' do
     let(:capybara_client) { Percy::Capybara::Client.new(enabled: true) }
+
     it 'returns block result on success' do
       result = capybara_client.rescue_connection_failures do
         true

--- a/spec/lib/percy/capybara/loaders/filesystem_loader_spec.rb
+++ b/spec/lib/percy/capybara/loaders/filesystem_loader_spec.rb
@@ -7,18 +7,21 @@ RSpec.describe Percy::Capybara::Loaders::FilesystemLoader do
   describe 'initialize' do
     context 'assets_dir not specified' do
       let(:assets_dir) { nil }
+
       it 'raises an error' do
         expect { loader }.to raise_error(ArgumentError)
       end
     end
     context 'assets_dir is not an absolute path' do
       let(:assets_dir) { '../../client/testdata' }
+
       it 'raises an error' do
         expect { loader }.to raise_error(ArgumentError)
       end
     end
     context 'assets_dir doesn\'t exist' do
       let(:assets_dir) { File.expand_path('../../client/testdata-doesnt-exist', __FILE__) }
+
       it 'raises an error' do
         expect { loader }.to raise_error(ArgumentError)
       end
@@ -130,6 +133,7 @@ RSpec.describe Percy::Capybara::Loaders::FilesystemLoader do
     end
     context 'assets_dir with only skippable resources' do
       let(:assets_dir) { File.expand_path('../../client/testdata/assets/images', __FILE__) }
+
       it 'returns an empty list' do
         expect(loader.build_resources).to eq([])
       end

--- a/spec/lib/percy/capybara/loaders/filesystem_loader_spec.rb
+++ b/spec/lib/percy/capybara/loaders/filesystem_loader_spec.rb
@@ -110,6 +110,23 @@ RSpec.describe Percy::Capybara::Loaders::FilesystemLoader do
         ]
         expect(actual_urls).to match_array(expected_urls)
       end
+      it 'works with different base_url configs' do
+        loader = described_class.new(base_url: '/url-prefix/', assets_dir: assets_dir)
+        expected_urls = loader.build_resources.collect(&:resource_url)
+        expect(expected_urls).to include('/url-prefix/css/font.css')
+
+        loader = described_class.new(base_url: '/url-prefix', assets_dir: assets_dir)
+        expected_urls = loader.build_resources.collect(&:resource_url)
+        expect(expected_urls).to include('/url-prefix/css/font.css')
+
+        loader = described_class.new(base_url: '/', assets_dir: assets_dir)
+        expected_urls = loader.build_resources.collect(&:resource_url)
+        expect(expected_urls).to include('/css/font.css')
+
+        loader = described_class.new(base_url: '', assets_dir: assets_dir)
+        expected_urls = loader.build_resources.collect(&:resource_url)
+        expect(expected_urls).to include('/css/font.css')
+      end
     end
     context 'assets_dir with only skippable resources' do
       let(:assets_dir) { File.expand_path('../../client/testdata/assets/images', __FILE__) }

--- a/spec/lib/percy/capybara/loaders/filesystem_loader_spec.rb
+++ b/spec/lib/percy/capybara/loaders/filesystem_loader_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Percy::Capybara::Loaders::FilesystemLoader do
   let(:fake_page) { OpenStruct.new(current_url: 'http://localhost/foo') }
   let(:assets_dir) { File.expand_path('../../client/testdata', __FILE__) }
-  let(:base_url) { '/url-prefix' }
+  let(:base_url) { '/url-prefix/' }
   let(:loader) { described_class.new(base_url: base_url, assets_dir: assets_dir, page: fake_page) }
 
   describe 'initialize' do

--- a/spec/lib/percy/capybara/loaders/native_loader_spec.rb
+++ b/spec/lib/percy/capybara/loaders/native_loader_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Percy::Capybara::Loaders::NativeLoader do
   end
   describe 'nonlocal.me', type: :feature, js: true do
     let(:orig_app_host) { Capybara.app_host }
+
     before do
       Capybara.app_host = Capybara.app_host.gsub('http://localhost:', 'http://localtest.me:')
     end
@@ -113,6 +114,7 @@ RSpec.describe Percy::Capybara::Loaders::NativeLoader do
 
     context 'when loader is initialised with asset hostnames' do
       let(:asset_hostnames) { ['dev.local'] }
+
       context 'with the same port' do
         it 'returns in accordance with asset_hostnames' do
           expect(loader._should_include_url?('http://dev.local/')).to eq(true)
@@ -136,6 +138,7 @@ RSpec.describe Percy::Capybara::Loaders::NativeLoader do
     end
     context 'for nonlocal hosts' do
       let(:fake_page) { OpenStruct.new(current_url: 'http://foo:123/') }
+
       it 'returns true for the same host port' do
         expect(loader._should_include_url?('http://foo:123/')).to eq(true)
         expect(loader._should_include_url?('http://foo:123/bar')).to eq(true)


### PR DESCRIPTION
In the filesystem loader, if baseurl was set to `/` or had a trailing slash like `/url-prefix/`, it would create URLs like `/url-prefix//index.html` which would break rendering. This fixes that bug.