### PR TITLE
Sprockets 4 support for rails 5 & 5.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,32 @@ Style/TrailingCommaInLiteral:
 RSpec/MessageSpies:
   EnforcedStyle: receive
 
+Style/FileName:
+  Exclude:
+    - 'Gemfile'
+    - 'Guardfile'
+    - 'percy-capybara.gemspec'
+
+Style/EmptyLineAfterMagicComment:
+  Exclude:
+    - 'percy-capybara.gemspec'
+
+Style/PercentLiteralDelimiters:
+  Exclude:
+    - 'percy-capybara.gemspec'
+
+Style/UnneededPercentQ:
+  Exclude:
+    - 'percy-capybara.gemspec'
+
+Style/RegexpLiteral:
+  Exclude:
+    - 'percy-capybara.gemspec'
+
+Style/SymbolArray:
+  Exclude:
+    - 'spec/spec_helper.rb'
+
 # Will be able to do this in >= v1.11
 # RSpec/DescribedClass:
 #   EnforcedStyle: explicit

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ gem 'guard-rspec', require: false
 # gem 'percy-client', path: '~/src/percy-client'
 
 group :test do
-  gem 'rubocop'
+  gem 'rubocop', '~> 0.48.0'
   gem 'rubocop-rspec'
 end

--- a/lib/percy/capybara/loaders/native_loader.rb
+++ b/lib/percy/capybara/loaders/native_loader.rb
@@ -9,7 +9,7 @@ module Percy
       # This loader uses JavaScript to discover page resources, so specs must be tagged with
       # "js: true" because the default Rack::Test driver does not support executing JavaScript.
       class NativeLoader < BaseLoader # rubocop:disable ClassLength
-        PATH_REGEX = /\A\/[^\\s\"']*/
+        PATH_REGEX = %r{\A/[^\\s\"']*}
         DATA_URL_REGEX = /\Adata:/
         LOCAL_HOSTNAMES = [
           'localhost',

--- a/lib/percy/capybara/loaders/sprockets_loader.rb
+++ b/lib/percy/capybara/loaders/sprockets_loader.rb
@@ -93,16 +93,20 @@ module Percy
         end
 
         def _asset_logical_paths
-          # Re-implement the same technique that "rake assets:precompile" uses to generate the
-          # list of asset paths to include in compiled assets. https://goo.gl/sy2R4z
-          # We can't just use environment.each_logical_path without any filters, because then
-          # we will attempt to compile assets before they're rendered (such as _mixins.css).
-          precompile_list = sprockets_options.precompile
-          logical_paths = sprockets_environment.each_logical_path(*precompile_list).to_a
-          logical_paths += precompile_list.flatten.select do |filename|
-            Pathname.new(filename).absolute? if filename.is_a?(String)
+          if _rails && _rails.application.respond_to?(:precompiled_assets)
+            _rails.application.precompiled_assets
+          else
+            # Re-implement the same technique that "rake assets:precompile" uses to generate the
+            # list of asset paths to include in compiled assets. https://goo.gl/sy2R4z
+            # We can't just use environment.each_logical_path without any filters, because then
+            # we will attempt to compile assets before they're rendered (such as _mixins.css).
+            precompile_list = sprockets_options.precompile
+            logical_paths = sprockets_environment.each_logical_path(*precompile_list).to_a
+            logical_paths += precompile_list.flatten.select do |filename|
+              Pathname.new(filename).absolute? if filename.is_a?(String)
+            end
+            logical_paths.uniq
           end
-          logical_paths.uniq
         end
       end
     end

--- a/percy-capybara.gemspec
+++ b/percy-capybara.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'capybara-webkit', '>= 1.6', '< 1.12.0' # 1.12.0 breaks specs
   spec.add_development_dependency 'selenium-webdriver'
   spec.add_development_dependency 'webmock', '~> 1'
-  spec.add_development_dependency 'mime-types', '< 3'  # For Ruby 1.9 testing support.
+  spec.add_development_dependency 'mime-types', '< 3' # For Ruby 1.9 testing support.
   spec.add_development_dependency 'faraday', '>= 0.8'
   spec.add_development_dependency 'sprockets', '>= 3.2.0'
 end

--- a/spec/lib/percy/capybara/loaders/native_loader_spec.rb
+++ b/spec/lib/percy/capybara/loaders/native_loader_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Percy::Capybara::Loaders::NativeLoader do
       content = File.read(path)
       # In Ruby 1.9.3 the SVG mimetype is not registered so our mini ruby webserver doesn't serve
       # the correct content type. Allow either to work here so we can test older Rubies fully.
-      expect(resource.mimetype).to match(/image\/svg\+xml|application\/octet-stream/)
+      expect(resource.mimetype).to match(%r{image/svg\+xml|application/octet-stream})
       expected_sha = Digest::SHA256.hexdigest(content)
       expect(Digest::SHA256.hexdigest(resource.content)).to eq(expected_sha)
       expect(resource.sha).to eq(expected_sha)

--- a/spec/lib/percy/capybara/loaders/sprockets_loader_spec.rb
+++ b/spec/lib/percy/capybara/loaders/sprockets_loader_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Percy::Capybara::Loaders::SprocketsLoader do
         # Pretend like we're in a Rails app right now, all we care about is Rails.public_path.
         rails_double = double('Rails')
         # Pretend like the entire testdata directory is the public/ folder.
+        expect(rails_double).to receive(:application).and_return(nil)
         expect(rails_double).to receive(:public_path).and_return(environment.root + '/public')
         expect(loader).to receive(:_rails).at_least(:once).and_return(rails_double)
       end

--- a/spec/lib/percy/capybara/loaders/sprockets_loader_spec.rb
+++ b/spec/lib/percy/capybara/loaders/sprockets_loader_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Percy::Capybara::Loaders::SprocketsLoader do
   let(:sprockets_options) do
     options = double('options')
     # Set specific files we want to compile. In normal use, this would be all asset files.
-    precompile_list = [/(?:\/|\\|\A)(base|digested)\.(css|js)$|\.map|\.png/]
+    precompile_list = [%r{(?:/|\\|\A)(base|digested)\.(css|js)$|\.map|\.png}]
     allow(options).to receive(:precompile).and_return(precompile_list)
     allow(options).to receive(:digest).and_return(digest_enabled)
     options

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -40,7 +40,7 @@ module TestHelpers
     environment.append_path '.'
 
     sprockets_options = double('sprockets_options')
-    allow(sprockets_options).to receive(:precompile).and_return([/(?:\/|\\|\A)base\.(css|js)$/])
+    allow(sprockets_options).to receive(:precompile).and_return([%r{(?:/|\\|\A)base\.(css|js)$}])
     allow(sprockets_options).to receive(:digest).and_return(false)
 
     capybara_client.sprockets_environment = environment


### PR DESCRIPTION
Closes: #10 

FYI Rails 5.1.0.rc1 seems to be default to sprockets 4