### PR TITLE
don't try to upload duplicated resources

### DIFF
--- a/lib/percy/capybara/loaders/native_loader.rb
+++ b/lib/percy/capybara/loaders/native_loader.rb
@@ -31,7 +31,7 @@ module Percy
           resources += _get_css_resources
           resources += _get_image_resources
           resources += iframes_resources
-          resources
+          resources.uniq
         end
 
         def build_resources

--- a/percy-capybara.gemspec
+++ b/percy-capybara.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'percy-client', '~> 1.10'
+  spec.add_dependency 'percy-client', '~> 1.10', '> 1.10'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/percy-capybara.gemspec
+++ b/percy-capybara.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'percy-client', '~> 1.10', '> 1.10'
+  spec.add_dependency 'percy-client', '>= 1.11'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/spec/lib/percy/capybara/client/testdata/test-mixed-relative-and-absolute.html
+++ b/spec/lib/percy/capybara/client/testdata/test-mixed-relative-and-absolute.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<title>Test Percy::Capybara</title>
+
+<h2>img local PNG (absolute to root)</h2>
+<img src="/images/bg-relative.png">
+
+<h2>CSS background-image (relative)</h2>
+<div style="background-image: url(images/bg-relative.png); width: 200px; height: 200px;"></div>
+
+</html>

--- a/spec/lib/percy/capybara/loaders/filesystem_loader_spec.rb
+++ b/spec/lib/percy/capybara/loaders/filesystem_loader_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Percy::Capybara::Loaders::FilesystemLoader do
           '/test-iframe.html',
           '/test-images.html',
           '/test-localtest-me-images.html',
+          '/test-mixed-relative-and-absolute.html',
         ]
         expect(actual_paths).to match_array(expected_paths)
 
@@ -110,6 +111,7 @@ RSpec.describe Percy::Capybara::Loaders::FilesystemLoader do
           '/url-prefix/test-iframe.html',
           '/url-prefix/test-images.html',
           '/url-prefix/test-localtest-me-images.html',
+          '/url-prefix/test-mixed-relative-and-absolute.html',
         ]
         expect(actual_urls).to match_array(expected_urls)
       end

--- a/spec/lib/percy/capybara/loaders/native_loader_spec.rb
+++ b/spec/lib/percy/capybara/loaders/native_loader_spec.rb
@@ -84,6 +84,20 @@ RSpec.describe Percy::Capybara::Loaders::NativeLoader do
       expect(loader.snapshot_resources.collect(&:is_root)).to eq([true, nil])
     end
   end
+  describe 'mixed relative and absolute paths', type: :feature, js: true do
+    it 'returns unique list of resources' do
+      visit '/test-mixed-relative-and-absolute.html'
+      loader = described_class.new(page: page)
+      resource_urls = loader.snapshot_resources.collect(&:resource_url)
+
+      expect(resource_urls).to eq(
+        [
+          '/test-mixed-relative-and-absolute.html',
+          '/images/bg-relative.png',
+        ],
+      )
+    end
+  end
   describe '#_should_include_url?' do
     it 'returns true for valid, local URLs' do
       expect(loader._should_include_url?('http://localhost/')).to eq(true)


### PR DESCRIPTION
@fotinakis this builds on top of https://github.com/percy/percy-client/pull/13

resources can get duplicated when their paths are mix of absolute and
relative ones. https://github.com/percy/percy-client/pull/13 allows
making them unique just by calling Array#uniq

another approach would be to move https://github.com/percy/percy-capybara/blob/c165c1979ad254070c3e12035e49c700ab689302/lib/percy/capybara/loaders/native_loader.rb#L145 after the url was normalized few lines below