### PR TITLE
Add console output notification for builds.

### DIFF
--- a/lib/percy/capybara/client/builds.rb
+++ b/lib/percy/capybara/client/builds.rb
@@ -49,6 +49,8 @@ module Percy
             Percy.logger.error { 'Percy build failed! Check log above for errors.' }
             return
           end
+          build_url = current_build['data']['attributes']['web-url']
+          puts "\n[percy] Visual diffs are now processing: #{build_url}"
           result
         end
 

--- a/spec/lib/percy/capybara/client/builds_spec.rb
+++ b/spec/lib/percy/capybara/client/builds_spec.rb
@@ -128,6 +128,7 @@ RSpec.describe Percy::Capybara::Client::Builds do
     let(:build_data) do
       {'data' => {'id' => 123, 'attributes' => {'web-url' => 'http://localhost/'}}}
     end
+
     it 'finalizes the current build' do
       expect(capybara_client.client).to receive(:create_build).and_return(build_data)
       capybara_client.initialize_build

--- a/spec/lib/percy/capybara/client/builds_spec.rb
+++ b/spec/lib/percy/capybara/client/builds_spec.rb
@@ -125,8 +125,10 @@ RSpec.describe Percy::Capybara::Client::Builds do
     end
   end
   describe '#finalize_current_build' do
+    let(:build_data) do
+      {'data' => {'id' => 123, 'attributes' => {'web-url' => 'http://localhost/'}}}
+    end
     it 'finalizes the current build' do
-      build_data = {'data' => {'id' => 123}}
       expect(capybara_client.client).to receive(:create_build).and_return(build_data)
       capybara_client.initialize_build
 
@@ -139,7 +141,6 @@ RSpec.describe Percy::Capybara::Client::Builds do
       end.to raise_error(Percy::Capybara::Client::BuildNotInitializedError)
     end
     it 'safely handles connection errors' do
-      build_data = {'data' => {'id' => 123}}
       expect(capybara_client.client).to receive(:create_build).and_return(build_data)
       capybara_client.initialize_build
 


### PR DESCRIPTION
Something we should have been doing all along:

![screen shot 2017-06-07 at 12 01 04 pm](https://user-images.githubusercontent.com/75300/26896331-36ba8cca-4b79-11e7-991a-093a2172709c.png)

Considered adding a way to disable this logging, but we can always add that later as a backwards-compatible config setting.