### PR TITLE
Check to see if Sprockets::Rails is defined

### DIFF
--- a/lib/percy/capybara/client.rb
+++ b/lib/percy/capybara/client.rb
@@ -34,7 +34,7 @@ module Percy
         @client = options[:client] || \
           Percy.client(client_info: _client_info, environment_info: _environment_info)
 
-        return unless defined?(Rails)
+        return unless defined?(Rails) && defined?(Sprockets::Rails)
 
         @sprockets_environment = options[:sprockets_environment] || Rails.application.assets
         @sprockets_options = options[:sprockets_options] || Rails.application.config.assets


### PR DESCRIPTION
I ran into this issue as we're in the process of removing Sprockets from our Rails application. I also looks like someone else had this [issue](https://github.com/percy/percy-capybara/issues/18) at some point.

AppVeyor is failing but it seems unrelated to these changes, doesn't look like it's configured?