### PR TITLE
Update to token only build creation endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem 'guard-rspec', require: false
 
 # (for development)
 # gem 'percy-client', path: '~/src/percy-client'
-gem 'percy-client', :git => 'https://github.com/percy/percy-client.git', :branch => 'map/update-to-token-only-build-endpoint'
 
 group :test, :development do
   gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'guard-rspec', require: false
 
 # (for development)
 # gem 'percy-client', path: '~/src/percy-client'
+gem 'percy-client', :git => 'https://github.com/percy/percy-client.git', :branch => 'map/update-to-token-only-build-endpoint'
 
 group :test, :development do
   gem 'pry'

--- a/lib/percy/capybara/anywhere.rb
+++ b/lib/percy/capybara/anywhere.rb
@@ -14,8 +14,8 @@ module Percy
     #   end
     module Anywhere
       def self.run(server, assets_dir, assets_base_url = nil)
-        unless ENV['PERCY_PROJECT'] && ENV['PERCY_TOKEN']
-          raise 'Whoops! You need to setup the PERCY_PROJECT and PERCY_TOKEN environment variables.'
+        if ENV['PERCY_TOKEN'].nil?
+          raise 'Whoops! You need to setup the PERCY_TOKEN environment variable.'
         end
 
         ::Capybara.run_server = false

--- a/lib/percy/capybara/client.rb
+++ b/lib/percy/capybara/client.rb
@@ -42,12 +42,7 @@ module Percy
 
       # Check that environment variables required for Percy::Client are set
       def required_environment_variables_set?
-        if !ENV['PERCY_TOKEN'].nil? && ENV['PERCY_PROJECT'].nil?
-          raise '[percy] It looks like you were trying to enable Percy because PERCY_TOKEN ' \
-            'is set, but you are missing the PERCY_PROJECT environment variable!'
-        end
-
-        !(ENV['PERCY_PROJECT'].nil? || ENV['PERCY_TOKEN'].nil?)
+        !!ENV['PERCY_TOKEN']
       end
 
       def enabled?

--- a/lib/percy/capybara/client/builds.rb
+++ b/lib/percy/capybara/client/builds.rb
@@ -6,7 +6,6 @@ module Percy
           return unless enabled? # Silently skip if the client is disabled.
           return @current_build if build_initialized?
 
-
           # Gather build resources to upload with build.
           start = Time.now
           build_resources = options[:build_resources] || initialize_loader.build_resources
@@ -17,7 +16,7 @@ module Percy
           Percy.logger.debug { "All build resources loaded (#{Time.now - start}s)" }
 
           rescue_connection_failures do
-            @current_build = client.create_build(client.config.repo, options)
+            @current_build = client.create_build(options)
             _upload_missing_build_resources(build_resources) unless build_resources.empty?
           end
           if failed?

--- a/lib/percy/capybara/client/builds.rb
+++ b/lib/percy/capybara/client/builds.rb
@@ -6,6 +6,7 @@ module Percy
           return unless enabled? # Silently skip if the client is disabled.
           return @current_build if build_initialized?
 
+
           # Gather build resources to upload with build.
           start = Time.now
           build_resources = options[:build_resources] || initialize_loader.build_resources

--- a/percy-capybara.gemspec
+++ b/percy-capybara.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'percy-client', '~> 2.0.0'
+  spec.add_dependency 'percy-client', '~> 2.0'
   spec.add_dependency 'addressable', '~> 2'
 
   spec.add_development_dependency 'bundler', '~> 1.7'

--- a/percy-capybara.gemspec
+++ b/percy-capybara.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'percy-client', '~> 1.13'
+  spec.add_dependency 'percy-client', '~> 2.0.0'
   spec.add_dependency 'addressable', '~> 2'
 
   spec.add_development_dependency 'bundler', '~> 1.7'

--- a/spec/lib/percy/capybara/client/builds_spec.rb
+++ b/spec/lib/percy/capybara/client/builds_spec.rb
@@ -1,9 +1,7 @@
 RSpec.describe Percy::Capybara::Client::Builds do
   let(:enabled) { true }
   let(:capybara_client) { Percy::Capybara::Client.new(enabled: enabled) }
-  let(:builds_api_url) do
-    "https://percy.io/api/v1/repos/#{Percy::Client::Environment.repo}/builds/"
-  end
+  let(:builds_api_url) { "https://percy.io/api/v1/builds/" }
 
   describe '#initialize_build', type: :feature, js: true do
     before(:each) { setup_sprockets(capybara_client) }
@@ -104,7 +102,7 @@ RSpec.describe Percy::Capybara::Client::Builds do
     it 'returns the current build' do
       mock_double = double('build')
       expect(capybara_client.client).to receive(:create_build)
-        .with(capybara_client.client.config.repo, {})
+        .with({})
         .and_return(mock_double)
         .once
       capybara_client.initialize_build

--- a/spec/lib/percy/capybara/client/snapshots_spec.rb
+++ b/spec/lib/percy/capybara/client/snapshots_spec.rb
@@ -47,8 +47,7 @@ RSpec.describe Percy::Capybara::Client::Snapshots, type: :feature do
 
         visit '/'
         loader # Force evaluation now.
-        repo = Percy::Client::Environment.repo
-        stub_request(:post, "https://percy.io/api/v1/repos/#{repo}/builds/")
+        stub_request(:post, "https://percy.io/api/v1/builds/")
           .to_return(status: 201, body: mock_build_response.to_json)
         stub_request(:post, 'https://percy.io/api/v1/builds/123/snapshots/')
           .to_return(status: 201, body: mock_snapshot_response.to_json)

--- a/spec/lib/percy/capybara/client_spec.rb
+++ b/spec/lib/percy/capybara/client_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Percy::Capybara::Client do
         expect(Percy::Capybara::Client.new.enabled?).to eq(false)
       end
 
-      it 'raises error if PERCY_TOKEN is set but PERCY_PROJECT is not' do
-        ENV.delete 'PERCY_PROJECT'
-        expect { Percy::Capybara::Client.new.enabled? }.to raise_error(RuntimeError)
+      it 'is false if PERCY_TOKEN is not set' do
+        ENV.delete 'PERCY_TOKEN'
+        expect(Percy::Capybara::Client.new.enabled?).to eq(false)
       end
     end
 

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -50,13 +50,11 @@ module TestHelpers
   # Set the environment variables required by Percy::Client
   def set_required_env_variables
     ENV['PERCY_TOKEN'] = 'aa'
-    ENV['PERCY_PROJECT'] = 'aa'
   end
 
   # Clear the environment variables required by Percy::Client
   def clear_percy_env_variables
     ENV.delete('PERCY_TOKEN')
-    ENV.delete('PERCY_PROJECT')
     ENV.delete('PERCY_ENABLE')
   end
 end


### PR DESCRIPTION
Removes checks for `PERCY_PROJECT` to enable support for the new token only build creation endpoint.

Note: this will be updated with the new `percy-client` gem before it is shipped.
https://github.com/percy/percy-client/pull/39