### PR TITLE
Bump target ruby version to make rubocop happy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,4 +11,4 @@ RSpec/ContextWording:
   Enabled: false
 
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2


### PR DESCRIPTION
Looks like this just needs a gentle bump to make tests pass again.