### PR TITLE
Non-static iframe resource discovery using FilesystemLoader

### DIFF
--- a/lib/percy/capybara/loaders/filesystem_loader.rb
+++ b/lib/percy/capybara/loaders/filesystem_loader.rb
@@ -25,7 +25,7 @@ module Percy
         end
 
         def snapshot_resources
-          [root_html_resource]
+          [root_html_resource] + iframes_resources
         end
 
         def build_resources

--- a/spec/lib/percy/capybara/client/test_data/test-dynamic-iframe.html
+++ b/spec/lib/percy/capybara/client/test_data/test-dynamic-iframe.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <title>Test dynamic iframe</title>
+  <body>
+    <iframe src="/dynamic-iframe/"></iframe>
+  </body>
+</html>

--- a/spec/lib/percy/capybara/loaders/filesystem_loader_spec.rb
+++ b/spec/lib/percy/capybara/loaders/filesystem_loader_spec.rb
@@ -54,6 +54,19 @@ RSpec.describe Percy::Capybara::Loaders::FilesystemLoader do
       resource_urls = loader.snapshot_resources.collect(&:resource_url)
       expect(resource_urls).to match_array(['/test-css.html'])
     end
+    it 'finds non-static iframe resource' do
+      visit '/test-dynamic-iframe.html'
+      loader = Percy::Capybara::Loaders::FilesystemLoader.new(
+        base_url: base_url,
+        assets_dir: assets_dir,
+        page: page,
+        include_iframes: true
+      )
+      resource_urls = loader.snapshot_resources.collect(&:resource_url)
+      # /dynamic-iframe/ does not match any static asset so won't be discovered
+      # already by #build_resources
+      expect(resource_urls).to match_array(['/test-dynamic-iframe.html', '/dynamic-iframe/'])
+    end
   end
 
   describe '#build_resources' do
@@ -89,6 +102,7 @@ RSpec.describe Percy::Capybara::Loaders::FilesystemLoader do
           '/test-css.html',
           '/test-font.html',
           '/test-iframe.html',
+          '/test-dynamic-iframe.html',
           '/test-images.html',
           '/test-localtest-me-images.html',
         ]
@@ -122,6 +136,7 @@ RSpec.describe Percy::Capybara::Loaders::FilesystemLoader do
           '/url-prefix/test-css.html',
           '/url-prefix/test-font.html',
           '/url-prefix/test-iframe.html',
+          '/url-prefix/test-dynamic-iframe.html',
           '/url-prefix/test-images.html',
           '/url-prefix/test-localtest-me-images.html',
         ]


### PR DESCRIPTION
Adds a spec that `FilesystemLoader` will find additional iframe resources referenced by visited pages that weren't already discovered in `assets_dir` by `build_resources`.