### PR TITLE
Remove Ruby 2.2 and 2.3 from CI configuration. Add Ruby 2.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,7 @@ default_steps: &default_steps
           && wget -O /tmp/phantomjs.tar.bz2 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
           && tar -xjf /tmp/phantomjs.tar.bz2 -C /tmp
           && sudo mv /tmp/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
-    # For Ruby 2.2 we can't just do gem update --system, because it will pull rubygems >3.0,
-    # which doesn't work on Ruby 2.2. See: https://github.com/rubygems/rubygems/issues/2534
-    - run: gem i rubygems-update -v '<3' && update_rubygems
+    - run: gem update --system
     # We need this specific version of bundler for our Gemfile. (v2 doesn't work)
     - run: gem install bundler --version '1.7'
     - run: bundle install
@@ -23,17 +21,13 @@ jobs:
     docker:
       - image: circleci/ruby:latest-node-browsers
     <<: *default_steps
+  ruby_25:
+    docker:
+      - image: circleci/ruby:2.5-node-browsers
+    <<: *default_steps
   ruby_24:
     docker:
       - image: circleci/ruby:2.4-node-browsers
-    <<: *default_steps
-  ruby_23:
-    docker:
-      - image: circleci/ruby:2.3-node-browsers
-    <<: *default_steps
-  ruby_22:
-    docker:
-      - image: circleci/ruby:2.2.6-node-browsers
     <<: *default_steps
 
 workflows:
@@ -41,6 +35,5 @@ workflows:
   test:
     jobs:
       - ruby_latest
+      - ruby_25
       - ruby_24
-      - ruby_23
-      - ruby_22


### PR DESCRIPTION
Ruby 2.2 is EOL, and Ruby 2.3 will be EOL by the end of this month (see: https://www.ruby-lang.org/en/downloads/branches/). Remove them from our CI configuration, and add Ruby 2.5 instead. (We also run our CI on `ruby-latest`, which is currently 2.6.x.)