### PR TITLE
Import version file into environment.rb

### DIFF
--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -1,3 +1,5 @@
+require 'version'
+
 module Percy
   def self.client_info
     "percy-capybara/#{VERSION}"


### PR DESCRIPTION
This is an attempt to fix the error:
```
     Failure/Error: Percy.snapshot(page)
     
     NameError:
       uninitialized constant Percy::VERSION
     # /Library/Ruby/Gems/2.3.0/gems/percy-capybara-4.0.0.pre.beta1/lib/environment.rb:3:in `client_info'
     # /Library/Ruby/Gems/2.3.0/gems/percy-capybara-4.0.0.pre.beta1/lib/percy.rb:33:in `snapshot'
```

That I got trying to use the `4.0.0.pre.beta1` version of the Gem.