### PR TITLE
fix: Enable JavaScript for builds

### DIFF
--- a/lib/percy.rb
+++ b/lib/percy.rb
@@ -106,7 +106,7 @@ module Percy
   # For Ruby style, require snake_case args but transform them into camelCase for percy-agent.
   def self._keys_to_json(options)
     {
-      enable_javascript: :enableJavascript,
+      enable_javascript: :enableJavaScript,
       min_height: :minHeight,
     }.each do |ruby_key, json_key|
       if options.has_key? ruby_key

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@percy/agent": "^0.1.15"
+    "@percy/agent": "~0"
   }
 }

--- a/spec/lib/percy/percy_spec.rb
+++ b/spec/lib/percy/percy_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 RSpec.describe Percy, type: :feature do
   TEST_CASE_GLOB =  File.join(File.dirname(__FILE__), "./capybara/client/test_data/test-*.html")
 
@@ -38,6 +39,10 @@ RSpec.describe Percy, type: :feature do
       it 'recognizes minHeight' do
         visit 'http://example.com'
         Percy.snapshot(page, { name: 'minHeight', minHeight: 2000 })
+      end
+      it 'recognizes enableJavascript' do
+        visit 'http://example.com'
+        Percy.snapshot(page, { name: 'enableJavaScript', enable_javascript: true })
       end
     end
   end

--- a/spec/lib/percy/percy_spec.rb
+++ b/spec/lib/percy/percy_spec.rb
@@ -51,9 +51,9 @@ RSpec.describe Percy, type: :feature do
     it 'transforms keys from snake_case to JSON-style' do
       original = { enable_javascript: true, min_height: 2000 }
       transformed = Percy._keys_to_json(original)
-      expect(transformed.has_key? 'enableJavascript')
+      expect(transformed.has_key? 'enableJavaScript')
       expect(transformed.has_key? 'minHeight')
-      expect(transformed['enableJavascript']).to eq(original[:enable_javascript])
+      expect(transformed['enableJavaScript']).to eq(original[:enable_javascript])
       expect(transformed['minHeight']).to eq(original[:min_height])
     end
   end

--- a/spec/lib/percy/percy_spec.rb
+++ b/spec/lib/percy/percy_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 RSpec.describe Percy, type: :feature do
   TEST_CASE_GLOB =  File.join(File.dirname(__FILE__), "./capybara/client/test_data/test-*.html")
 
@@ -40,7 +39,7 @@ RSpec.describe Percy, type: :feature do
         visit 'http://example.com'
         Percy.snapshot(page, { name: 'minHeight', minHeight: 2000 })
       end
-      it 'recognizes enableJavascript' do
+      it 'recognizes enable_javascript' do
         visit 'http://example.com'
         Percy.snapshot(page, { name: 'enableJavaScript', enable_javascript: true })
       end


### PR DESCRIPTION
## What is this?

Looks like the key that was being passed isn't using the right casing for `@percy/agent`. `enableJavascript` is deprecated and apparently doesn't work. `enableJavaScript` is the correct way and does work. 

### TODO

What's a good test for this that would surface JS not working in a snapshot? Probably introduce our own page? 