### PR TITLE
Add metadata to gemspec

### DIFF
--- a/percy-capybara.gemspec
+++ b/percy-capybara.gemspec
@@ -13,6 +13,11 @@ Gem::Specification.new do |spec|
   spec.homepage      = ''
   spec.license       = 'MIT'
 
+  spec.metadata = {
+    'bug_tracker_uri' => 'https://github.com/percy/percy-capybara/issues',
+    'source_code_uri' => 'https://github.com/percy/percy-capybara',
+  }
+
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Purpose:
- Add useful links to <https://rubygems.org/gems/percy-capybara>.
- Expect useful integrations with 3rd-party tools (e.g. Dependabot).

See also:
- https://guides.rubygems.org/specification-reference/#metadata