### PR TITLE
fix: Add log if the health check endpoint fails

### DIFF
--- a/lib/percy.rb
+++ b/lib/percy.rb
@@ -98,7 +98,8 @@ module Percy
     begin
       Net::HTTP.get(AGENT_HOST, '/percy/healthcheck', AGENT_PORT)
       return true
-    rescue
+    rescue => e
+      self._logger.error { "Healthcheck failed, agent is not running: #{e}" }
       return false
     end
   end


### PR DESCRIPTION
## What is this?

This PR adds a rescue to catch the error log when the health check fails. If the health check fails we'll never capture snapshots so it's super helpful to know why it's failing.