### PR TITLE
fix: Only log healthcheck fail when `LOG_LEVEL=debug` is set

### DIFF
--- a/lib/percy.rb
+++ b/lib/percy.rb
@@ -66,6 +66,11 @@ module Percy
 
   def self._make_dom_snapshot(page)
     agent_js = self._get_agent_js
+
+    if self._is_debug?
+      self._logger.info { "agent_js file: #{agent_js}" }
+    end
+
     return unless agent_js
 
     begin
@@ -99,7 +104,10 @@ module Percy
       Net::HTTP.get(AGENT_HOST, '/percy/healthcheck', AGENT_PORT)
       return true
     rescue => e
-      self._logger.error { "Healthcheck failed, agent is not running: #{e}" }
+      if self._is_debug?
+        self._logger.error { "Healthcheck failed, agent is not running: #{e}" }
+      end
+
       return false
     end
   end
@@ -116,5 +124,9 @@ module Percy
       end
     end
     return options
+  end
+
+  def self._is_debug?
+    ENV['LOG_LEVEL'] == 'debug'
   end
 end


### PR DESCRIPTION
## What is this?

If you're running your test suite without percy started, these health check logs would be very noisy and annoying. This PR will make it so they only log if you're setting the log level to `debug`. 