### PR TITLE
Refer to VERSION constant with full path

### DIFF
--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -2,7 +2,7 @@ require 'version'
 
 module Percy
   def self.client_info
-    "percy-capybara/#{VERSION}"
+    "percy-capybara/#{Percy::VERSION}"
   end
 
   def self.environment_info


### PR DESCRIPTION
To avoid conflicts with Rails autoloading VERSION constants from other
packages.