### PR TITLE
Require Percy version file specifically

### DIFF
--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -1,4 +1,4 @@
-require 'version'
+require_relative './version'
 
 module Percy
   def self.client_info


### PR DESCRIPTION
If other version.rb files are in the load path, then it'll load them
instead leading to fun conflicts (error message in Rails is along the
lines of: `Unable to autoload constant VERSION...`)

This requires the Percy version file specifically. I believe other gems
have solved this by using a subfolder under `/lib` that contains the Gem
name rather than adding generic files in `lib` to the load path which
might cause more fun errors in future :) Happy to send a PR with that
change too if you'd like!