### PR TITLE
fix: pass options to DOM capture

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,6 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 
   # See https://github.com/teamcapybara/capybara#selecting-the-driver for other options
-  Capybara.default_driver = :selenium_chrome_headless
-  Capybara.javascript_driver = :selenium_chrome_headless
+  Capybara.default_driver = :selenium_headless
+  Capybara.javascript_driver = :selenium_headless
 end


### PR DESCRIPTION
## What is this?

This will allow for proper serialization of iframes since that relies on checking for `enable_javascript` (`enableJavaScript`) being passed when capturing the DOM. 