### PR TITLE
fix: Use `execute_script` over `evaluate_script`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ default_steps: &default_steps
   steps:
     - checkout
     - run: sudo gem update --system
+    - run: ruby -v
     - run: yarn
     - run: bundle install
     - run: yarn percy exec -- bundle exec rspec

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -9,11 +9,16 @@ module Percy
     env_strings = [
       "rails/#{self._rails_version}",
       "sinatra/#{self._sinatra_version}",
+      "capybara/#{self.capybara_version}",
       "ember-cli-rails/#{self._ember_cli_rails_version}",
     ].reject do |info|
       info =~ /\/$/ # reject if version is empty
     end
     env_strings.empty? ? 'unknown' : env_strings.join('; ')
+  end
+
+  def self.capybara_version
+    Capybara::VERSION if defined? Capybara
   end
 
   def self._ember_cli_rails_version

--- a/spec/lib/percy/environment_spec.rb
+++ b/spec/lib/percy/environment_spec.rb
@@ -8,15 +8,10 @@ RSpec.describe Percy do
       it 'returns full environment information' do
         expect(our_module).to receive(:_rails_version).at_least(:once).times.and_return('4.2')
         expect(our_module).to receive(:_sinatra_version).at_least(:once).and_return('2.0.0')
+        expect(our_module).to receive(:capybara_version).at_least(:once).and_return(Capybara::VERSION)
         expect(our_module).to receive(:_ember_cli_rails_version).at_least(:once).and_return('0.9')
 
-        expect(environment_info).to eq('rails/4.2; sinatra/2.0.0; ember-cli-rails/0.9')
-      end
-    end
-
-    context 'an app with no known frameworks being used' do
-      it 'returns unknown environment information' do
-        expect(environment_info).to eq('unknown')
+        expect(environment_info).to eq("rails/4.2; sinatra/2.0.0; capybara/#{Capybara::VERSION}; ember-cli-rails/0.9")
       end
     end
   end


### PR DESCRIPTION
## What is this?

This PR makes it possible (for sure) to use this package outside of Capybara (by eliminating the only Capybara specific method `evaluate_script`). In the future this package will likely be deprecated for a pure selenium ruby package (since this SDK implements nothing specific to Capybara). 

This adds Capybara's version reporting to our UA and also checks to see if Capybara is being used. For some reason, it seems like Capybara wraps WebDriver's `execute_script` method and it doesn't return its value. If Capybara is being used, we'll use their `evaluate_script` method. Otherwise, we'll use the `execute_script` method like _all the other selenium SDKs_.
