### PR TITLE
🐛  Use `require_relative` for ::VERSION

### DIFF
--- a/percy-capybara.gemspec
+++ b/percy-capybara.gemspec
@@ -1,14 +1,11 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'percy/version'
+require_relative './lib/percy/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'percy-capybara'
   spec.version       = PercyCapybara::VERSION
   spec.authors       = ['Perceptual Inc.']
   spec.email         = ['team@percy.io']
-  spec.summary       = %q{Percy}
+  spec.summary       = %q{Percy visual testing for Capybara}
   spec.description   = %q{}
   spec.homepage      = ''
   spec.license       = 'MIT'


### PR DESCRIPTION
## What is this?

According to this blog post the load path stuff we were doing in the gemspec is old hat: https://piotrmurach.com/articles/writing-a-ruby-gem-specification/

> This was a popular method to load a version file during the 1.8.7 and 1.9.2 Ruby era. It still remains popular, for example, for loading binary files. However, we can do better now. That’s where the require_relative method comes handy. It will load a file relative to the current location. Exactly what we need. All the three lines can be replaced in one fell swoop with:

When installing the beta into the example app I got an error about loading the VERSION module -- this should fix the issue. 