### PR TITLE
🐛  require `version` in `percy/capybara`

### DIFF
--- a/lib/percy/capybara.rb
+++ b/lib/percy/capybara.rb
@@ -1,6 +1,7 @@
 require 'net/http'
 require 'uri'
 require 'capybara/dsl'
+require_relative './version'
 
 module PercyCapybara
   include Capybara::DSL

--- a/percy-capybara.gemspec
+++ b/percy-capybara.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
     'source_code_uri' => 'https://github.com/percy/percy-capybara',
   }
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = Dir.glob("{lib}/**/*") + %w(LICENSE README.md)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']


### PR DESCRIPTION
## What is this?

I missed requiring the version file into the capybara file in #164. This also updates the included/distributed files in the gemspec file (removes tests files & includes the version file) 