### PR TITLE
🧹 Add stale issues/PRs action, update releaser config for new labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+name: Bug report
+about: Create a report to help us fix the issue
+title: ''
+labels: ''
+assignees: ''
+---
+<!--
+## Reach out to Percy support instead?
+
+If you’re having issues that _aren’t SDK bugs_, it would be best for you to
+reach out to support instead: support@percy.io or
+https://www.browserstack.com/contact#technical-support
+-->
+
+## The problem
+
+Briefly describe the issue you are experiencing (or the feature you want to see
+added to Percy). Tell us what you were trying to do and what happened
+instead. Remember, this is _not_ a place to ask questions. For that, go to
+https://github.com/percy/cli/discussions/new
+
+## Environment
+
+- Node version:
+- `@percy/cli` version:
+- Version of Percy SDK you’re using:
+- If needed, a build or snapshot ID:
+- OS version:
+- Type of shell command-line [interface]:
+
+## Details
+
+If necessary, describe the problem you have been experiencing in more detail.
+
+## Debug logs
+
+If you are reporting a bug, _always_ include logs! Run a Percy build with
+`--verbose` to get the full debug logs. You can also set an environment var
+`PERCY_LOGLEVEL=debug` to get debug logs. For example, `percy exec --verbose --
+[test command]`.  Please include the full complete test output.
+
+## Code to reproduce issue
+
+Given the nature of testing/environment bugs, it’s best to try and isolate the
+issue in a reproducible repo. This will make it much easier for us to diagnose
+and fix.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,29 +3,26 @@ tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: '💥 Breaking Changes'
     labels:
-      - breaking
+      - 💥 breaking
   - title: '✨ Enhancements'
     labels:
-      - feature
-      - enhancement
+      - ✨ enhancement
   - title: '🐛 Bug Fixes'
     labels:
-      - fix
-      - bugfix
-      - bug
-  - title: '🏗  Maintenance'
+      - 🐛 bug
+  - title: '🏗 Maintenance'
     labels:
-      - chore
-      - dependencies
+      - 🧹 maintenance
+  - title: '⬆️⬇️ Dependency Updates'
+    labels:
+      - ⬆️⬇️ dependencies
 change-title-escapes: '\<*_&#@'
 version-resolver:
   major:
     labels:
-      - breaking
+      - 💥 breaking
   minor:
     labels:
-      - feature
-      - enhancement
+      - ✨ enhancement
   default: patch
 template: '$CHANGES'
-prerelease: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '0 19 * * 2'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: >-
+            This issue is stale because it has been open for more than 14 days with no activity.
+            Remove stale label or comment or this will be closed in 14 days.
+          stale-pr-message: >-
+            This PR is stale because it has been open for more than 14 days with no activity.
+            Remove stale label or comment or this will be closed in 14 days.
+          close-issue-message: >-
+            This issue was closed because it has been stalled for 28 days with no activity.
+          close-pr-message: >-
+            This PR was closed because it has been stalled for 28 days with no activity.
+          days-before-issue-stale: 14
+          days-before-pr-stale: 14
+          # close 14 days _after_ initial warning
+          days-before-issue-close: 14
+          days-before-pr-close: 14
+          exempt-pr-labels: '❄️ on ice'
+          exempt-issue-labels: '🐛 bug,❄️ on ice,✨ enhancement'
+          exempt-all-assignees: true
+          stale-pr-label: '🍞 stale'


### PR DESCRIPTION
## What is this?

Three house keeping tasks in this PR:

- We recently updated all Percy SDK repos to have the same set of labels. The release drafter action config needs to be updated to use the new label names. 

- Add an issue template to help capture the typical info needed in order to debug / triage. Hopefully can help save a few comment asking for that common info

- Track/close stale issues and PRs. Anything with no activity for 14 days will get a warning comment. If there is no activity for another 14 days (28 total), the issue/PR will be closed. 