### PR TITLE
✅ Silence selenium warning coming from Capybara

### DIFF
--- a/percy-capybara.gemspec
+++ b/percy-capybara.gemspec
@@ -23,10 +23,11 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'capybara', '>= 3'
 
-  spec.add_development_dependency 'selenium-webdriver', '>= 4.0.0.beta1'
+  spec.add_development_dependency 'selenium-webdriver', '>= 4.0.0'
+  spec.add_development_dependency 'geckodriver-bin', '~> 0.28.0'
   spec.add_development_dependency 'bundler', '>= 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.5'
-  spec.add_development_dependency 'capybara', '~> 3.31'
+  spec.add_development_dependency 'capybara', '~> 3.36.0'
   spec.add_development_dependency 'percy-style', '~> 0.7.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ SimpleCov.minimum_coverage 100
 require 'capybara/rspec'
 require 'webmock/rspec'
 require 'percy/capybara'
+require 'selenium-webdriver'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -40,6 +41,9 @@ RSpec.configure do |config|
   Capybara.server_port = 3003
   Capybara.server = :puma, { Silent: true }
   Capybara.app = Rack::File.new(File.join(File.dirname(__FILE__), 'fixture'))
+
+  # Ignore warning until Capybara releases an update solving their warning
+  Selenium::WebDriver.logger.ignore(:browser_options)
 end
 
 ## Add cache clearing methods for tests


### PR DESCRIPTION
## What is this?

According to this issue the fix has been merged into capybara but hasn't been released yet. https://github.com/teamcapybara/capybara/issues/2511

This will fix tests failing since the deprecation pops up in the log output, which we're asserting against 