### PR TITLE
fix: merge .percy.yml config options with snapshot options for serializeDOM

### DIFF
--- a/lib/percy/capybara.rb
+++ b/lib/percy/capybara.rb
@@ -1,3 +1,4 @@
+require 'json'
 require 'net/http'
 require 'uri'
 require 'capybara/dsl'
@@ -29,8 +30,12 @@ module PercyCapybara
       # older CLIs that lack waitForReady.
       readiness_diagnostics = wait_for_ready(page, options)
 
+      # Merge .percy.yml config options with snapshot options (snapshot options take priority)
+      config_options = @cli_config&.dig('snapshot') || {}
+      merged_options = config_options.merge(options)
+
       dom_snapshot = page
-        .evaluate_script("(function() { return PercyDOM.serialize(#{options.to_json}) })()")
+        .evaluate_script("(function() { return PercyDOM.serialize(#{merged_options.to_json}) })()")
 
       if readiness_diagnostics && dom_snapshot.is_a?(Hash)
         dom_snapshot['readiness_diagnostics'] = readiness_diagnostics
@@ -77,6 +82,8 @@ module PercyCapybara
         return false
       end
 
+      body = JSON.parse(response.body)
+      @cli_config = body['config'] || {}
       @percy_enabled = true
       true
     rescue StandardError => e

--- a/lib/percy/capybara.rb
+++ b/lib/percy/capybara.rb
@@ -34,8 +34,11 @@ module PercyCapybara
       config_options = @cli_config&.dig('snapshot') || {}
       merged_options = config_options.merge(options.transform_keys(&:to_s))
 
+      # Strip the SDK-internal `readiness` key so it does not leak into serialize.
+      serialize_options = merged_options.reject { |k, _| k == 'readiness' }
+
       dom_snapshot = page
-        .evaluate_script("(function() { return PercyDOM.serialize(#{merged_options.to_json}) })()")
+        .evaluate_script("(function() { return PercyDOM.serialize(#{serialize_options.to_json}) })()")
 
       if readiness_diagnostics && dom_snapshot.is_a?(Hash)
         dom_snapshot['readiness_diagnostics'] = readiness_diagnostics
@@ -49,9 +52,8 @@ module PercyCapybara
         environment_info: ENV_INFO,
         **options,)
 
-      unless response.body.to_json['success']
-        raise StandardError, data['error']
-      end
+      parsed = (JSON.parse(response.body) rescue {})
+      raise StandardError, (parsed['error'] || 'Unknown error') unless parsed['success']
     rescue StandardError => e
       log("Could not take DOM snapshot '#{name}'")
 

--- a/lib/percy/capybara.rb
+++ b/lib/percy/capybara.rb
@@ -34,11 +34,8 @@ module PercyCapybara
       config_options = @cli_config&.dig('snapshot') || {}
       merged_options = config_options.merge(options.transform_keys(&:to_s))
 
-      # Strip the SDK-internal `readiness` key so it does not leak into serialize.
-      serialize_options = merged_options.reject { |k, _| k == 'readiness' }
-
       dom_snapshot = page
-        .evaluate_script("(function() { return PercyDOM.serialize(#{serialize_options.to_json}) })()")
+        .evaluate_script("(function() { return PercyDOM.serialize(#{merged_options.to_json}) })()")
 
       if readiness_diagnostics && dom_snapshot.is_a?(Hash)
         dom_snapshot['readiness_diagnostics'] = readiness_diagnostics
@@ -52,8 +49,9 @@ module PercyCapybara
         environment_info: ENV_INFO,
         **options,)
 
-      parsed = (JSON.parse(response.body) rescue {})
-      raise StandardError, (parsed['error'] || 'Unknown error') unless parsed['success']
+      unless response.body.to_json['success']
+        raise StandardError, data['error']
+      end
     rescue StandardError => e
       log("Could not take DOM snapshot '#{name}'")
 
@@ -84,17 +82,8 @@ module PercyCapybara
         return false
       end
 
-      parsed = if response.body.to_s.empty?
-        {}
-      else
-        begin
-          JSON.parse(response.body)
-        rescue JSON::ParserError
-          {}
-        end
-      end
-      config = parsed.is_a?(Hash) ? parsed['config'] : nil
-      @cli_config = config.is_a?(Hash) ? config : {}
+      body = response.body.to_s.empty? ? {} : JSON.parse(response.body)
+      @cli_config = body['config'] || {}
       @percy_enabled = true
       true
     rescue StandardError => e

--- a/lib/percy/capybara.rb
+++ b/lib/percy/capybara.rb
@@ -82,8 +82,17 @@ module PercyCapybara
         return false
       end
 
-      body = response.body.to_s.empty? ? {} : JSON.parse(response.body)
-      @cli_config = body['config'] || {}
+      parsed = if response.body.to_s.empty?
+        {}
+      else
+        begin
+          JSON.parse(response.body)
+        rescue JSON::ParserError
+          {}
+        end
+      end
+      config = parsed.is_a?(Hash) ? parsed['config'] : nil
+      @cli_config = config.is_a?(Hash) ? config : {}
       @percy_enabled = true
       true
     rescue StandardError => e

--- a/lib/percy/capybara.rb
+++ b/lib/percy/capybara.rb
@@ -30,9 +30,11 @@ module PercyCapybara
       # older CLIs that lack waitForReady.
       readiness_diagnostics = wait_for_ready(page, options)
 
-      # Merge .percy.yml config options with snapshot options (snapshot options take priority)
+      # Merge .percy.yml config options with snapshot options (snapshot options take priority).
+      # Deep merge with consistent string keys at all levels: nested Hashes merge
+      # recursively, per-call wins at leaves, arrays/scalars replace.
       config_options = @cli_config&.dig('snapshot') || {}
-      merged_options = config_options.merge(options.transform_keys(&:to_s))
+      merged_options = deep_merge_options(config_options, deep_stringify(options))
 
       dom_snapshot = page
         .evaluate_script("(function() { return PercyDOM.serialize(#{merged_options.to_json}) })()")
@@ -133,6 +135,24 @@ module PercyCapybara
     rescue StandardError => e
       if PERCY_DEBUG then log("waitForReady failed, proceeding to serialize: #{e}") end
       nil
+    end
+  end
+
+  # Recursively stringify all Hash keys so per-call options match the
+  # string-keyed config parsed from .percy.yml JSON at every nesting level.
+  private def deep_stringify(obj)
+    case obj
+    when Hash then obj.each_with_object({}) { |(k, v), h| h[k.to_s] = deep_stringify(v) }
+    when Array then obj.map { |e| deep_stringify(e) }
+    else obj
+    end
+  end
+
+  # Deep-merge two string-keyed Hashes: nested Hashes merge recursively,
+  # per-call (override) wins at the leaves, arrays/scalars replace.
+  private def deep_merge_options(base, override)
+    base.merge(override) do |_key, old_val, new_val|
+      old_val.is_a?(Hash) && new_val.is_a?(Hash) ? deep_merge_options(old_val, new_val) : new_val
     end
   end
 

--- a/lib/percy/capybara.rb
+++ b/lib/percy/capybara.rb
@@ -32,7 +32,7 @@ module PercyCapybara
 
       # Merge .percy.yml config options with snapshot options (snapshot options take priority)
       config_options = @cli_config&.dig('snapshot') || {}
-      merged_options = config_options.merge(options)
+      merged_options = config_options.merge(options.transform_keys(&:to_s))
 
       dom_snapshot = page
         .evaluate_script("(function() { return PercyDOM.serialize(#{merged_options.to_json}) })()")
@@ -82,7 +82,7 @@ module PercyCapybara
         return false
       end
 
-      body = JSON.parse(response.body)
+      body = response.body.to_s.empty? ? {} : JSON.parse(response.body)
       @cli_config = body['config'] || {}
       @percy_enabled = true
       true

--- a/spec/lib/percy/percy_capybara_spec.rb
+++ b/spec/lib/percy/percy_capybara_spec.rb
@@ -173,5 +173,56 @@ RSpec.describe PercyCapybara, type: :feature do
         .to have_requested(:post, "#{PercyCapybara::PERCY_SERVER_ADDRESS}/percy/snapshot")
         .once
     end
+
+    # --- .percy.yml config <-> per-snapshot merge precedence ----
+
+    it 'merges .percy.yml config with per-call options (per-call wins, no dup keys)' do
+      # Healthcheck returns a config with a snapshot block: a config-only key
+      # (enableJavaScript) plus a percyCSS the per-call option will override.
+      stub_request(:get, "#{PercyCapybara::PERCY_SERVER_ADDRESS}/percy/healthcheck")
+        .to_return(
+          status: 200,
+          body: {
+            config: {
+              'snapshot' => {
+                'enableJavaScript' => true,
+                'percyCSS' => 'FROM_CONFIG',
+              },
+            },
+          }.to_json,
+          headers: {'x-percy-core-version': '1.0.0'},
+        )
+      stub_request(:get, "#{PercyCapybara::PERCY_SERVER_ADDRESS}/percy/dom.js")
+        .to_return(
+          status: 200,
+          body: 'window.PercyDOM = { serialize: () => ({html: "<html></html>"}) };',
+          headers: {},
+        )
+      stub_request(:post, 'http://localhost:5338/percy/snapshot')
+        .to_return(status: 200, body: '{"success": "true"}', headers: {})
+
+      # Capture the JS string passed to PercyDOM.serialize without a real browser.
+      # evaluate_script is called twice: once to inject @percy/dom (fetch_percy_dom),
+      # then once for the serialize call we want to inspect.
+      serialize_script = nil
+      allow(page).to receive(:evaluate_script) do |script|
+        serialize_script = script if script.include?('PercyDOM.serialize')
+        {'html' => '<html></html>'}
+      end
+
+      page.percy_snapshot('merge-precedence', percyCSS: 'FROM_CALL')
+
+      expect(serialize_script).not_to be_nil
+      # Extract the JSON object handed to PercyDOM.serialize.
+      json = serialize_script[/PercyDOM\.serialize\((\{.*\})\)/m, 1]
+      merged = JSON.parse(json)
+
+      # Config-only key survives the merge.
+      expect(merged['enableJavaScript']).to eq(true)
+      # Per-call option overrides the config value.
+      expect(merged['percyCSS']).to eq('FROM_CALL')
+      # No duplicate percyCSS key (string vs symbol collision avoided).
+      expect(json.scan(/"percyCSS"/).size).to eq(1)
+    end
   end
 end

--- a/spec/lib/percy/percy_capybara_spec.rb
+++ b/spec/lib/percy/percy_capybara_spec.rb
@@ -212,9 +212,11 @@ RSpec.describe PercyCapybara, type: :feature do
 
       page.percy_snapshot('merge-precedence', percyCSS: 'FROM_CALL')
 
-      expect(serialize_script).not_to be_nil
+      expect(serialize_script).to_not be_nil
       # Extract the JSON object handed to PercyDOM.serialize.
-      json = serialize_script[/PercyDOM\.serialize\((\{.*\})\)/m, 1]
+      # Non-greedy so we stop at the matching close brace and don't swallow the
+      # trailing `) })()` from the wrapping IIFE.
+      json = serialize_script[/PercyDOM\.serialize\((\{.*?\})\)/m, 1]
       merged = JSON.parse(json)
 
       # Config-only key survives the merge.

--- a/spec/lib/percy/percy_capybara_spec.rb
+++ b/spec/lib/percy/percy_capybara_spec.rb
@@ -226,5 +226,51 @@ RSpec.describe PercyCapybara, type: :feature do
       # No duplicate percyCSS key (string vs symbol collision avoided).
       expect(json.scan(/"percyCSS"/).size).to eq(1)
     end
+
+    it 'deep-merges nested config blocks with per-call options (per-call wins at leaves)' do
+      # Config has a nested discovery block; the per-call discovery overrides
+      # only one leaf. A shallow merge would drop networkIdleTimeout entirely;
+      # the deep merge must keep it while applying the per-call disableCache.
+      stub_request(:get, "#{PercyCapybara::PERCY_SERVER_ADDRESS}/percy/healthcheck")
+        .to_return(
+          status: 200,
+          body: {
+            config: {
+              'snapshot' => {
+                'discovery' => {
+                  'networkIdleTimeout' => 50,
+                  'disableCache' => false,
+                },
+              },
+            },
+          }.to_json,
+          headers: {'x-percy-core-version': '1.0.0'},
+        )
+      stub_request(:get, "#{PercyCapybara::PERCY_SERVER_ADDRESS}/percy/dom.js")
+        .to_return(
+          status: 200,
+          body: 'window.PercyDOM = { serialize: () => ({html: "<html></html>"}) };',
+          headers: {},
+        )
+      stub_request(:post, 'http://localhost:5338/percy/snapshot')
+        .to_return(status: 200, body: '{"success": "true"}', headers: {})
+
+      serialize_script = nil
+      allow(page).to receive(:evaluate_script) do |script|
+        serialize_script = script if script.include?('PercyDOM.serialize')
+        {'html' => '<html></html>'}
+      end
+
+      page.percy_snapshot('deep-merge', discovery: {disableCache: true})
+
+      expect(serialize_script).to_not be_nil
+      json = serialize_script[/PercyDOM\.serialize\((\{.*?\})\)/m, 1]
+      merged = JSON.parse(json)
+
+      # Nested config-only leaf survives the deep merge.
+      expect(merged.dig('discovery', 'networkIdleTimeout')).to eq(50)
+      # Per-call leaf overrides the nested config value.
+      expect(merged.dig('discovery', 'disableCache')).to eq(true)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,5 +51,6 @@ Capybara::Session.class_eval {
   def __percy_clear_cache!
     @percy_dom = nil
     @percy_enabled = nil
+    @cli_config = nil
   end
 }


### PR DESCRIPTION
## Summary
- Config options from `.percy.yml` were not being passed to `PercyDOM.serialize()`
- Only per-snapshot options were used for DOM serialization
- Now stores config from healthcheck response and merges `config['snapshot']` with user options

## Test plan
- [ ] Existing tests pass
- [ ] Verify `.percy.yml` config options are applied during DOM serialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)