### PR TITLE
🔖 Release 5.0.1.pre.0 (PER-7348)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    percy-capybara (5.0.0)
+    percy-capybara (5.0.1.pre.0)
       capybara (>= 3)
 
 GEM

--- a/lib/percy/version.rb
+++ b/lib/percy/version.rb
@@ -1,3 +1,3 @@
 module PercyCapybara
-  VERSION = '5.0.0'.freeze
+  VERSION = '5.0.1.pre.0'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
       "test": "percy exec --testing -- bundle exec rspec"
     },
     "devDependencies": {
-      "@percy/cli": "^1.16.0"
+      "@percy/cli": "^1.31.15-beta.0"
     }
   }


### PR DESCRIPTION
Prerelease (beta) shipping the **PER-7348 readiness gate** (`waitForReady` before serialize), merged in #330.

### Version bump → `5.0.1.pre.0`
- `lib/percy/version.rb` — `PercyCapybara::VERSION` (repo prerelease idiom `.pre.N`)
- `package.json` — `@percy/cli` devDependency → `^1.31.15-beta.0` (readiness-capable)

Capybara runs readiness via `evaluate_async_script` + `done` callback, so it is **unaffected** by the `page.evaluate` top-level-`return` bug fixed in percy/cli#2247. Publishing the GitHub release triggers `make release` → `gem push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)