### PR TITLE
ci: publish gem natively (drop cadwallion/publish-rubygems-action)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           path: "./vendor/bundle"
           key: v1/${{ runner.os }}/ruby-2.6/${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: v1/${{ runner.os }}/ruby-2.6/
-      - uses: cadwallion/publish-rubygems-action@master
+      - name: Build and publish gem to RubyGems
+        run: make release
         env:
-          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
-          RELEASE_COMMAND: make release
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}


### PR DESCRIPTION
## Problem
The `5.0.1.pre.0` release workflow [failed](https://github.com/percy/percy-capybara/actions/runs/26718179895/job/78740377174) — the gem never reached RubyGems.

Root cause: the unpinned **`cadwallion/publish-rubygems-action@master`** Docker image has drifted to **Ruby 3.4 + bundler 2.1.4**. Ruby 3.4 removed `DidYouMean::SPELL_CHECKERS`, which the old vendored Thor (in bundler 2.1.4) still references, so `rake build` crashes before `gem push`:
```
rake aborted!
NameError: uninitialized constant DidYouMean::SPELL_CHECKERS
make: *** [Makefile:2: release] Error 1
```
The `ruby-version: 2.6` in the workflow was ignored because the action runs in its own container.

## Fix
Run `make release` **natively** under the already-configured `ruby/setup-ruby@v1` (2.6), and authenticate `gem push` via `GEM_HOST_API_KEY`. This drops the unpinned third-party container entirely and is immune to base-image drift.

## Note
This fixes the build/runtime crash. Publishing still requires a **valid `RUBYGEMS_API_KEY`** secret with push rights for `percy-capybara` (the current one dates to 2021 and should be verified/rotated). After merge, re-publish the `5.0.1.pre.0` GitHub Release (or re-run the Release workflow) to push the gem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)