### PR TITLE
Revert RUBYGEMS_API_KEY debug step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Release
 on:
   release:
     types: [published]
-  workflow_dispatch:
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -17,22 +16,7 @@ jobs:
           path: "./vendor/bundle"
           key: v1/${{ runner.os }}/ruby-2.6/${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: v1/${{ runner.os }}/ruby-2.6/
-      - name: Debug secret presence
-        env:
-          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-        run: |
-          if [ -z "$RUBYGEMS_API_KEY" ]; then
-            echo "❌ ERROR: RUBYGEMS_API_KEY is empty or missing in Settings → Secrets!"
-            exit 1
-          fi
-          # Detect trailing whitespace/newline (the prime suspect for the
-          # gem push 401) WITHOUT disclosing the value or its length.
-          case "$RUBYGEMS_API_KEY" in
-            *[![:space:]]) echo "✅ RUBYGEMS_API_KEY present, no trailing whitespace." ;;
-            *) echo "⚠️ RUBYGEMS_API_KEY present but has trailing whitespace/newline — re-set it with printf (no newline)." ;;
-          esac
       - name: Build and publish gem to RubyGems
-        if: github.event_name == 'release'
         run: |
           mkdir -p ~/.gem
           cat << EOF > ~/.gem/credentials


### PR DESCRIPTION
Reverts the temporary CI debugging added in [#342](https://github.com/percy/percy-capybara/commit/a643a6ac7e9c2d5d0c7b19d2e80fb0eb1cfb4365).

That commit added a **Debug secret presence** step to the release workflow (plus a `workflow_dispatch` trigger and an `if: github.event_name == 'release'` guard for it) to diagnose the gem-push `401 Access Denied`. The diagnosis is done and the gem now publishes, so the debug scaffolding is no longer needed.

Doing this as a fresh revert PR rather than from the GitHub UI because several commits landed on top of #342 (`#343` env key, `#344` credentials block, the `v5.0.1.pre.1` release) and a UI revert wouldn't apply cleanly.

### What this removes
- The `Debug secret presence` step
- The `workflow_dispatch:` trigger (only added so the debug step could be triggered manually)
- The `if: github.event_name == 'release'` guard on the publish step (only needed to stop `workflow_dispatch` runs from publishing — moot once the trigger is gone)

### What this keeps (legitimate later changes)
- The `~/.gem/credentials` write block (from #344)
- `GEM_HOST_API_KEY` / `RUBYGEMS_API_KEY` env on the publish step (from #343/#344)

Net effect: the publish step is unchanged in behavior; only the debug-only additions are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)