### PR TITLE
release v5.0.1.pre.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    percy-capybara (5.0.1.pre.1)
+    percy-capybara (5.0.1.pre.2)
       capybara (>= 3)
 
 GEM

--- a/lib/percy/version.rb
+++ b/lib/percy/version.rb
@@ -1,3 +1,3 @@
 module PercyCapybara
-  VERSION = '5.0.1.pre.1'.freeze
+  VERSION = '5.0.1.pre.2'.freeze
 end


### PR DESCRIPTION
Bumps version to `5.0.1.pre.2`.

- `lib/percy/version.rb`: `5.0.1.pre.1` → `5.0.1.pre.2`
- `Gemfile.lock`: PATH spec updated to `5.0.1.pre.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)