### PR TITLE
chore: release 5.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    percy-capybara (5.0.1.pre.3)
+    percy-capybara (5.0.1)
       capybara (>= 3)
 
 GEM

--- a/lib/percy/version.rb
+++ b/lib/percy/version.rb
@@ -1,3 +1,3 @@
 module PercyCapybara
-  VERSION = '5.0.1.pre.3'.freeze
+  VERSION = '5.0.1'.freeze
 end


### PR DESCRIPTION
Promotes the PER-8053 config-merge work from the current pre-release to stable `5.0.1`. Config is deep-merged into serializeDOM (per-call priority); verified via the cross-SDK sanity sweep. Gemfile.lock updated to match so frozen-mode bundle install passes.