### PR TITLE
chore: release 5.0.2.pre.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    percy-capybara (5.0.1)
+    percy-capybara (5.0.2.pre.0)
       capybara (>= 3)
 
 GEM

--- a/lib/percy/version.rb
+++ b/lib/percy/version.rb
@@ -1,3 +1,3 @@
 module PercyCapybara
-  VERSION = '5.0.1'.freeze
+  VERSION = '5.0.2.pre.0'.freeze
 end


### PR DESCRIPTION
Beta bump to `5.0.2.pre.0` so the PER-10430 fix can be verified against a published gem before it goes out as a stable release.

## Changes

Version bump only — no functional changes.

- `lib/percy/version.rb`: `5.0.1` → `5.0.2.pre.0`
- `Gemfile.lock`: PATH spec synced to match

## ⚠️ Merge order

**This must merge *after* #369**, otherwise the beta ships without the fix it exists to validate.

#369 fixes percy-capybara 5.0.1 silently dropping every snapshot on non-Selenium Capybara drivers (`private method 'browser' called for an instance of Capybara::Playwright::Driver`) — see PER-10430 / #368.

## What the beta is for

Two things need real-world verification that local testing can't fully cover:

1. **The reporter's setup** (#368) — Rails system tests on `capybara-playwright-driver`. They can install the beta and confirm snapshots upload again.
2. **Cross-version behaviour** — the fix makes the SDK send `corsIframes` for the first time. Older `@percy/cli` (< 1.32.0, before CLI-side support landed in `1.32.0-beta.2`) is expected to strip the unknown key with a warning and proceed. That was verified against a *simulated* pre-1.32 schema, not a real old binary, so a beta run against genuinely older CLI versions is worth doing before the stable release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)